### PR TITLE
Fix compton-trans -c

### DIFF
--- a/bin/compton-trans
+++ b/bin/compton-trans
@@ -83,7 +83,7 @@ while test $# -gt 0; do
       s) wprefix=''; window='' ;;
       c)
         active=$(xprop -root -notype _NET_ACTIVE_WINDOW \
-          | sed 's/^.*\(0x\S*\).*$/\1/')
+          | grep -Eo '0x[[:xdigit:]]+' | head -n 1)
         wprefix='-id'; window=$active
       ;;
       r) action='reset' ;;


### PR DESCRIPTION
The pipeline used to retrieve the WID of the active window returns a bad WID because xprop returns several hex numbers and ".\*" in the sed regex is greedy. For instance, running `xprop -root -notype _NET_ACTIVE_WINDOW` gives me:
`_NET_ACTIVE_WINDOW: window id # 0x1a0003d, 0x0`
Filtering this output with the sed substitution then gives `0x0`, since the first ".\*" matches everything up to *the last* hex number.

The fix is simply to grep hex numbers instead of using a sed substitution, and then choose the first one.